### PR TITLE
User management bugs fixed

### DIFF
--- a/src/containers/UserManagementContainer/UserManagement.jsx
+++ b/src/containers/UserManagementContainer/UserManagement.jsx
@@ -42,7 +42,7 @@ const convertDataToRowsForTable = (records, selectedRecords) => records.map((rec
     const {
         id, name, phone_number, _quarantine_type, isolation_start_date, isolation_end_date, _address
     } = record;
-    const selectedRecord = selectedRecords.find((r) => r.phone_number === phone_number);
+    const selectedRecord = selectedRecords.find((r) => r.id === id);
     const startDate = moment(isolation_start_date);
     const endDate = moment(isolation_end_date);
     const daysRemaining = endDate.diff(startDate, 'days');
@@ -136,13 +136,17 @@ class UserManagement extends PureComponent{
 
     handleTransferPatients = () => {
         const { selectedPatients } = this.state;
-        const { volunteer, transferVolunteer, transferPatients } = this.props;
+        const { volunteer, transferVolunteer, transferPatients, showSnackbar } = this.props;
         this.handleDropdown();
-        transferPatients({
-            patients: selectedPatients,
-            fromId: volunteer.id,
-            toId: transferVolunteer.id,
-        });
+        if (volunteer.id === transferVolunteer.id) {
+            showSnackbar({ variant: 'warning', message: `Can't transfer patients to the same Volunteer` })
+        } else {
+            transferPatients({
+                patients: selectedPatients,
+                fromId: volunteer.id,
+                toId: transferVolunteer.id,
+            });
+        }
     }
 
     handleRowCheckboxClick = (row) => {
@@ -404,6 +408,7 @@ UserManagement.propTypes = {
     fetchTransferVolunteer: PropTypes.func.isRequired,
     transferPatients: PropTypes.func.isRequired,
     toggleUserModifierPane: PropTypes.func.isRequired,
+    showSnackbar: PropTypes.func.isRequired,
     volunteer: PropTypes.object.isRequired,
     fetchingVolunteer: PropTypes.bool.isRequired,
     fetchedVolunteer: PropTypes.bool.isRequired,

--- a/src/containers/UserManagementContainer/index.jsx
+++ b/src/containers/UserManagementContainer/index.jsx
@@ -3,6 +3,7 @@ import { bindActionCreators } from 'redux';
 import UserManagement from './UserManagement';
 import { searchVolunteerByNumber, deleteVolunteer, fetchTransferVolunteer, transferPatients } from '../../actions/userManagementActions';
 import { toggleUserModifierPane, editVolunteer } from '../../actions/userModifierPaneActions';
+import { showSnackbar, hideSnackbar } from '../../actions/snackbarAction';
 
 const mapStateToProps = (state) => ({
     volunteer: state.userManagementReducer.volunteer,
@@ -23,6 +24,7 @@ const mapStateToProps = (state) => ({
 const mapDispatchToProps = (dispatch) => bindActionCreators({
     searchVolunteerByNumber, deleteVolunteer, fetchTransferVolunteer,
     toggleUserModifierPane, editVolunteer, transferPatients,
+    showSnackbar, hideSnackbar,
 }, dispatch);
 
 const UserManagementContainer = connect(mapStateToProps, mapDispatchToProps)(UserManagement);

--- a/src/containers/UserModifierPaneContainer/UserModifierPane.jsx
+++ b/src/containers/UserModifierPaneContainer/UserModifierPane.jsx
@@ -12,6 +12,7 @@ class UserModifierPane extends PureComponent {
             login: '',
             zone: '',
             ward: '',
+            fieldsChanged: false,
         };
 
         this.handleChange = this.handleChange.bind(this);
@@ -38,6 +39,10 @@ class UserModifierPane extends PureComponent {
     }
 
     handleChange = (field) => (event) => {
+        const { fieldsChanged } = this.state;
+        const { editableVolunteer } = this.props;
+        const editMode = Object.keys(editableVolunteer).length > 0;
+
         if (['zone'].includes(field)) {
             this.setState({
                 [field]: event,
@@ -54,6 +59,29 @@ class UserModifierPane extends PureComponent {
             }
         }
         else this.setState({ [field]: event.target.value });
+
+        if (editMode) {
+            const { name, login, _zone, ward } = editableVolunteer;
+            const mirrorInitialState = {
+                name, login,
+                zone: _zone ? _zone.name : '',
+                ward
+            };
+
+            if (['zone', 'ward'].includes(field) && mirrorInitialState[field] !== event && !fieldsChanged) {
+                this.setState({ fieldsChanged: true });
+            }
+            else if (['zone', 'ward'].includes(field) && mirrorInitialState[field] === event && fieldsChanged) {
+                this.setState({ fieldsChanged: false });
+            }
+
+            if (['name', 'login'].includes(field) && mirrorInitialState[field] !== event.target.value && !fieldsChanged) {
+                this.setState({ fieldsChanged: true });
+            }
+            else if (['name', 'login'].includes(field) && mirrorInitialState[field] === event.target.value && fieldsChanged) {
+                this.setState({ fieldsChanged: false });
+            }
+        }
     }
 
     handleClose = () => {
@@ -145,16 +173,16 @@ class UserModifierPane extends PureComponent {
     }
 
     renderFooter = () => {
-        const { name, login, zone, ward } = this.state;
+        const { name, login, zone, ward, fieldsChanged } = this.state;
         const { editableVolunteer } = this.props;
         const editMode = Object.keys(editableVolunteer).length > 0;
         return (
             <div className="footer">
                 <button
                     onClick={() => this.handleSubmit()}
-                    disabled={name === '' || login === '' || zone === '' || ward === '' || login.length !== 10}
+                    disabled={(name === '' || login === '' || zone === '' || ward === '' || login.length !== 10) || (editMode && !fieldsChanged)}
                 >
-                    {editMode ? 'Edit Volunteer' : 'Add Volunteer'}
+                    {editMode ? 'Save Volunteer' : 'Add Volunteer'}
                 </button>
             </div>
         );

--- a/src/containers/UserModifierPaneContainer/index.css
+++ b/src/containers/UserModifierPaneContainer/index.css
@@ -80,3 +80,7 @@
     background: #3C6886;
     color: white;
 }
+.request-form-container .request-form .footer button:disabled {
+    background: #cccccc;
+    cursor: default;
+}


### PR DESCRIPTION
These are the bugs fixed:

1. System getting down when I have transferred record from 9942316140 to 9786014218 and refreshed the page in https://focusdev.gccservice.in/ to check whether the records to get updated in account, then system keeping on loading then throwing session timeout error and again I’m trying to login with same number(9786014218) system displayed invalid credential (FYI..i have faced same issue yesterday also. Please refer below screenshots)
And https://coviddev.gccservice.in/dashboard App also Getting blank (crashed)

![image](https://user-images.githubusercontent.com/24646060/89101055-344e3400-d41a-11ea-8e05-39d05f5e8417.png)

![image](https://user-images.githubusercontent.com/24646060/89101056-3a441500-d41a-11ea-96ed-e549717aa0cd.png)

![image](https://user-images.githubusercontent.com/24646060/89101058-3e703280-d41a-11ea-8e06-8dd3eefbc3bc.png)

![image](https://user-images.githubusercontent.com/24646060/89101059-40d28c80-d41a-11ea-9e9d-21e44fcec874.png)

![image](https://user-images.githubusercontent.com/24646060/89101061-44661380-d41a-11ea-9fad-0feb1b73a339.png)


2. If select 2 records in user management, system selected all records- Select and deselect function is not working properly (Test No. 8667881171)

3. System not restricting transferring within same number (Ex-transfer from 123 to 123)- system should displayed msg like "selected no is same something like that..

4. System allowed to create duplicate user in user management system (System should not allowed to create user with same number)

5. Suggestion - Edit volunteer button should be changed to [Save]

![image](https://user-images.githubusercontent.com/24646060/89101071-68c1f000-d41a-11ea-8ef3-c00eddfcae76.png)

6. System allowed to save without changing any value while we editing existing record in user management, [Save] button should be disabled (system generating post request in backend)
